### PR TITLE
Add support for RAML 1.0 arrays with a single element

### DIFF
--- a/raml-sanitize.js
+++ b/raml-sanitize.js
@@ -174,10 +174,10 @@ function toSanitization (configs, rules, types) {
 
       // Support RAML 1.0 array types for single values.
       const isTypeAnArray = Array.isArray(config.type)
-      const hasSingleType = () => config.type.length === 1
-      const isTypeArrayValue = () => config.type[0] === 'array'
+      const hasSingleType = config.type.length === 1
+      const isTypeArrayValue = config.type[0] === 'array'
       const isValueAnArray = Array.isArray(value)
-      const isSingleValueArrayType = isTypeAnArray && hasSingleType() && isTypeArrayValue() && !isValueAnArray
+      const isSingleValueArrayType = isTypeAnArray && hasSingleType && isTypeArrayValue && !isValueAnArray
 
       if (isSingleValueArrayType) {
         return [value]

--- a/raml-sanitize.js
+++ b/raml-sanitize.js
@@ -173,7 +173,13 @@ function toSanitization (configs, rules, types) {
       }
 
       // Support RAML 1.0 array types for single values.
-      if (Array.isArray(config.type) && config.type.length === 1 && config.type[0] === 'array' && !Array.isArray(value)) {
+      const isTypeAnArray = Array.isArray(config.type)
+      const hasSingleType = () => config.type.length === 1
+      const isTypeArrayValue = () => config.type[0] === 'array'
+      const isValueAnArray = Array.isArray(value)
+      const isSingleValueArrayType = isTypeAnArray && hasSingleType() && isTypeArrayValue() && !isValueAnArray
+
+      if (isSingleValueArrayType) {
         return [value]
       }
 

--- a/raml-sanitize.js
+++ b/raml-sanitize.js
@@ -172,6 +172,11 @@ function toSanitization (configs, rules, types) {
         value = value[0]
       }
 
+      // Support RAML 1.0 array types for single values.
+      if (Array.isArray(config.type) && config.type.length === 1 && config.type[0] === 'array' && !Array.isArray(value)) {
+        return [value]
+      }
+
       return sanitize(value, key, object)
     }
   })

--- a/test.js
+++ b/test.js
@@ -329,6 +329,20 @@ var TESTS = [
     { param: '["a", 1, tru]' },
     { param: '["a", 1, tru]' }
   ],
+  [
+    {
+      param: { type: ['array'] }
+    },
+    { param: 123 },
+    { param: [123] }
+  ],
+  [
+    {
+      param: { type: ['array'] }
+    },
+    { param: [123, 456] },
+    { param: [123, 456] }
+  ],
   /**
    * Object sanitization.
    */

--- a/test.js
+++ b/test.js
@@ -340,8 +340,57 @@ var TESTS = [
     {
       param: { type: ['array'] }
     },
+    { param: 'foo' },
+    { param: ['foo'] }
+  ],
+  [
+    {
+      param: { type: ['array'] }
+    },
+    { param: ['foo' ]},
+    { param: ['foo'] }
+  ],
+  [
+    {
+      param: { type: ['array'] }
+    },
+    { param: { foo: 'boo' } },
+    { param: [{ foo: 'boo' }] }
+  ],
+  [
+    {
+      param: { type: ['array'] }
+    },
     { param: [123, 456] },
     { param: [123, 456] }
+  ],
+  [
+    {
+      param: { type: ['string'] }
+    },
+    { param: '123' },
+    { param: '123' }
+  ],
+  [
+    {
+      param: { type: ['string', 'array'] }
+    },
+    { param: '123' },
+    { param: '123' }
+  ],
+  [
+    {
+      param: { type: ['string', 'array'] }
+    },
+    { param: 123 },
+    { param: 123 }
+  ],
+  [
+    {
+      param: { type: ['string', 'array'] }
+    },
+    { param: [123, 234] },
+    { param: [123, 234] }
   ],
   /**
    * Object sanitization.


### PR DESCRIPTION
# Add support for RAML 1.0 arrays with a single element

## Problem

When a RAML is written in 1.0 version and defines a query parameter of type `array` and in the request is only passed a single parameter then the sanitize will keep that element as it is instead of converting it to an array as it is made with `repeat` for RAML 0.8

## Solution

Validate the `type` property and check if it comes as RAML 1.0 way (an array instead of a string) if the type is  `type: ['array']` and the passed value is a single element `value: foo` then it is converted to an array

## Example

* a query parameter that is defined as type array is passed like `name=foo` then the sanitizing process will convert it to an array according to its defined type

* if a query parameter is passed like `name=foo&name=boo` this is already supported and the result is an array

## Pending

This is not fully sanitizing the passed array object as the lib currently does not support Type Expressions nor Union Types.